### PR TITLE
add lock param for plan job

### DIFF
--- a/src/jobs/plan.yml
+++ b/src/jobs/plan.yml
@@ -71,6 +71,10 @@ parameters:
     description: Configure a custom state lock timeout
     type: string
     default: 30s
+  lock:
+    description: Enable the lock on the state file or not
+    type: boolean
+    default: true
   resource_class:
     description: "Specify the resource class for Docker Executor"
     type: "string"
@@ -109,6 +113,7 @@ steps:
       out: << parameters.out >>
       timeout: <<parameters.timeout>>
       lock-timeout: <<parameters.lock-timeout>>
+      lock: <<parameters.lock>>
   - when:
       condition: << parameters.persist-workspace >>
       steps:


### PR DESCRIPTION
### Checklist

<!--
  Thank you for contributing to CircleCI Orbs!
  before submitting your request, please go through the following
  items and place an x in the [ ] if they have been completed.
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, Related Issues

currently lock-timeout is a parameter for plan job but lock is not, we were looking for the ability to omit locking when working from a feature branch and had to craft a workaround to get past this missing parameter

### Description

Adding lock parameter to plan job

